### PR TITLE
Expose a wayland socket

### DIFF
--- a/io.github.MakovWait.Godots.json
+++ b/io.github.MakovWait.Godots.json
@@ -16,6 +16,8 @@
     "finish-args" : [
         "--share=network",
         "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=x11",
         "--device=all",
         "--socket=pulseaudio",


### PR DESCRIPTION
This allows the Godot editor to respect the prefer wayland setting.